### PR TITLE
enh: improve buildConsumer types

### DIFF
--- a/core/src/nats.ts
+++ b/core/src/nats.ts
@@ -35,7 +35,7 @@ export const buildConsumer = async (
           const keyAsOptionsKeyType = key as keyof typeof options;
           return options[keyAsOptionsKeyType] !== config[keyAsOptionsKeyType]
       });
-    if (hasDifferentValue && options.durable_name != null) {
+    if (hasDifferentValue && options.durable_name) {
       logger.info('Updating consumer...');
       await jetstreamManager.consumers.update(stream, options.durable_name, options);
     }

--- a/core/src/nats.ts
+++ b/core/src/nats.ts
@@ -19,10 +19,9 @@ export const connectJetstream = (host: string) => {
 }
 
 export const buildConsumer = async (
-  { connection, options }:
-  { connection: NatsConnection, options: Partial<ConsumerConfig> }
+  { connection, stream, options }:
+  { connection: NatsConnection, stream: string, options: Partial<ConsumerConfig> }
 ) => {
-  const stream = "DebeziumStream";
   const jetstream = connection.jetstream();
   const jetstreamManager = await connection.jetstreamManager();
   let consumer;

--- a/core/src/nats.ts
+++ b/core/src/nats.ts
@@ -36,7 +36,7 @@ export const buildConsumer = async (
           const keyAsOptionsKeyType = key as keyof typeof options;
           return options[keyAsOptionsKeyType] !== config[keyAsOptionsKeyType]
       });
-    if (hasDifferentValue && options.durable_name) {
+    if (hasDifferentValue && options.durable_name != null) {
       logger.info('Updating consumer...');
       await jetstreamManager.consumers.update(stream, options.durable_name, options);
     }

--- a/core/src/nats.ts
+++ b/core/src/nats.ts
@@ -1,4 +1,4 @@
-import { connect, JSONCodec } from "nats";
+import { connect, ConsumerConfig, JSONCodec, NatsConnection } from "nats";
 
 import { logger } from './logger'
 
@@ -19,9 +19,10 @@ export const connectJetstream = (host: string) => {
 }
 
 export const buildConsumer = async (
-  { connection, stream, options }:
-  { connection: any, stream: string, options: any }
+  { connection, options }:
+  { connection: NatsConnection, options: Partial<ConsumerConfig> }
 ) => {
+  const stream = "DebeziumStream";
   const jetstream = connection.jetstream();
   const jetstreamManager = await connection.jetstreamManager();
   let consumer;
@@ -29,12 +30,18 @@ export const buildConsumer = async (
   try {
     consumer = await jetstream.consumers.get(stream, options.durable_name);
     const { config } = await consumer.info();
-    if (Object.keys(options).some(key => options[key] !== config[key])) {
+    const hasDifferentValue = Object
+      .keys(options)
+      .some(key => {
+          const keyAsOptionsKeyType = key as keyof typeof options;
+          return options[keyAsOptionsKeyType] !== config[keyAsOptionsKeyType]
+      });
+    if (hasDifferentValue && options.durable_name) {
       logger.info('Updating consumer...');
       await jetstreamManager.consumers.update(stream, options.durable_name, options);
     }
-  } catch (e: any) {
-    if (e.message !== "consumer not found") throw e;
+  } catch (e) {
+    if (e instanceof Error && e.message !== "consumer not found") throw e;
     logger.info('Creating consumer...');
     await jetstreamManager.consumers.add(stream, options);
     consumer = await jetstream.consumers.get(stream, options.durable_name);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -11,7 +11,7 @@ const main = (async () => {
 
   const consumer = await buildConsumer({
     connection: jetstreamConnection,
-    stream: "DebeziumStream",
+    stream: 'DebeziumStream',
     options: {
       durable_name: 'bemi-worker-local',
       filter_subject: 'bemi',

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -11,7 +11,6 @@ const main = (async () => {
 
   const consumer = await buildConsumer({
     connection: jetstreamConnection,
-    stream: 'DebeziumStream',
     options: {
       durable_name: 'bemi-worker-local',
       filter_subject: 'bemi',

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -11,6 +11,7 @@ const main = (async () => {
 
   const consumer = await buildConsumer({
     connection: jetstreamConnection,
+    stream: "DebeziumStream",
     options: {
       durable_name: 'bemi-worker-local',
       filter_subject: 'bemi',


### PR DESCRIPTION
This includes the following improvements:

- The parameters types become more specific.
- The stream is excluded from the parameter, because it's the fixed value.
- `options.durable_name` is added to the validation check, because the type of `update` requires the non-nullable value from `durable`.
- The type of `e` is checked by `instanceof` instead of using `any` type so that it infers its actual type properly.