### PR TITLE
enh: improve fetched record buffer types

### DIFF
--- a/core/src/fetched-record-buffer.ts
+++ b/core/src/fetched-record-buffer.ts
@@ -1,17 +1,13 @@
 import { FetchedRecord } from './fetched-record'
 
-type PositionRecords = { [position: string]: FetchedRecord[] }
-type SubjectRecords = { [subject: string]: PositionRecords }
-
 export class FetchedRecordBuffer {
-  store: SubjectRecords
+  store: { [subject: string]: { [position: string]: FetchedRecord[] } }
 
   constructor() {
     this.store = {}
   }
 
-  static fromStore(store: SubjectRecords) {
-    const buffer = new FetchedRecordBuffer()
+  static fromStore(store: { [subject: string]: { [position: string]: FetchedRecord[] } }) {    const buffer = new FetchedRecordBuffer()
     buffer.store = store
     return buffer
   }

--- a/core/src/fetched-record-buffer.ts
+++ b/core/src/fetched-record-buffer.ts
@@ -1,20 +1,23 @@
 import { FetchedRecord } from './fetched-record'
 
+type PositionRecords = { [position: string]: FetchedRecord[] }
+type SubjectRecords = { [subject: string]: PositionRecords }
+
 export class FetchedRecordBuffer {
-  store: { [subject: string]: { [position: string]: FetchedRecord[] } }
+  store: SubjectRecords
 
   constructor() {
     this.store = {}
   }
 
-  static fromStore(store: { [subject: string]: { [position: string]: FetchedRecord[] } }) {
+  static fromStore(store: SubjectRecords) {
     const buffer = new FetchedRecordBuffer()
     buffer.store = store
     return buffer
   }
 
   addFetchedRecord(fetchedRecord: FetchedRecord) {
-    const newBuffer = Object.assign(Object.create(this), this)
+    const newBuffer: FetchedRecordBuffer = Object.assign(Object.create(this), this)
     const { subject, changeAttributes } = fetchedRecord
     const position = changeAttributes.position.toString()
     const existingFetchedRecords = this.store[subject]?.[position]
@@ -35,7 +38,7 @@ export class FetchedRecordBuffer {
   }
 
   addFetchedRecords(fetchedRecords: FetchedRecord[]) {
-    let newBuffer = this
+    let newBuffer: FetchedRecordBuffer = this
 
     fetchedRecords.forEach((fetchedRecord: FetchedRecord) => {
       newBuffer = newBuffer.addFetchedRecord(fetchedRecord)

--- a/core/src/fetched-record-buffer.ts
+++ b/core/src/fetched-record-buffer.ts
@@ -7,7 +7,8 @@ export class FetchedRecordBuffer {
     this.store = {}
   }
 
-  static fromStore(store: { [subject: string]: { [position: string]: FetchedRecord[] } }) {    const buffer = new FetchedRecordBuffer()
+  static fromStore(store: { [subject: string]: { [position: string]: FetchedRecord[] } }) {
+    const buffer = new FetchedRecordBuffer()
     buffer.store = store
     return buffer
   }


### PR DESCRIPTION
This PR improves types:

- Create new type that is used in multiple places.
- Set the actual type by giving `FetchedRecordBuffer` instead of `any`.