### PR TITLE
enh: replace customized nats message type by js msg

### DIFF
--- a/core/src/fetched-record.ts
+++ b/core/src/fetched-record.ts
@@ -1,8 +1,8 @@
 import { RequiredEntityData } from '@mikro-orm/postgresql';
+import { JsMsg } from 'nats';
 
 import { Change, Operation } from "./entities/Change"
 import { decodeData } from './nats'
-import { JsMsg } from 'nats';
 
 export const MESSAGE_PREFIX_CONTEXT = '_bemi'
 export const MESSAGE_PREFIX_HEARTBEAT = '_bemi_heartbeat'

--- a/core/src/fetched-record.ts
+++ b/core/src/fetched-record.ts
@@ -1,7 +1,8 @@
 import { RequiredEntityData } from '@mikro-orm/postgresql';
 
 import { Change, Operation } from "./entities/Change"
-import { NatsMessage, decodeData } from './nats'
+import { decodeData } from './nats'
+import { JsMsg } from 'nats';
 
 export const MESSAGE_PREFIX_CONTEXT = '_bemi'
 export const MESSAGE_PREFIX_HEARTBEAT = '_bemi_heartbeat'
@@ -76,7 +77,7 @@ export class FetchedRecord {
     this.messagePrefix = messagePrefix
   }
 
-  static fromNatsMessage(natsMessage: NatsMessage, now = new Date()) {
+  static fromNatsMessage(natsMessage: JsMsg, now = new Date()) {
     const debeziumData = decodeData(natsMessage.data) as any
 
     const messagePrefix = debeziumData.message?.prefix

--- a/core/src/ingestion.ts
+++ b/core/src/ingestion.ts
@@ -1,11 +1,11 @@
 import { MikroORM } from '@mikro-orm/postgresql';
+import { Consumer, JsMsg } from 'nats';
 
 import { logger } from './logger'
 import { Change } from "./entities/Change"
 import { FetchedRecord } from './fetched-record'
 import { FetchedRecordBuffer } from './fetched-record-buffer'
 import { stitchFetchedRecords } from './stitching'
-import { Consumer, JsMsg } from 'nats';
 
 const INSERT_INTERVAL_MS = 1000 // 1 second to avoid overwhelming the database
 const FETCH_EXPIRES_MS = 30_000 // 30 seconds, default

--- a/core/src/nats.ts
+++ b/core/src/nats.ts
@@ -4,16 +4,6 @@ import { logger } from './logger'
 
 const JSON_CODEC = JSONCodec()
 
-export interface NatsMessage {
-  subject: string,
-  info: {
-    streamSequence: number,
-    pending: number,
-  },
-  data: any,
-  ack: () => void,
-}
-
 export const connectJetstream = (host: string) => {
   return connect({ servers: host });
 }

--- a/core/src/specs/fixtures/nats-messages.ts
+++ b/core/src/specs/fixtures/nats-messages.ts
@@ -222,7 +222,7 @@ export const buildNatsMessage = (
   seq: 0,
   sid: 0,
   subject,
-  info:  {
+  info: {
     streamSequence,
     pending: 0,
     domain: "",

--- a/core/src/specs/fixtures/nats-messages.ts
+++ b/core/src/specs/fixtures/nats-messages.ts
@@ -1,4 +1,5 @@
-import { NatsMessage, encodeData } from '../../nats'
+import { JsMsg } from 'nats'
+import { encodeData } from '../../nats'
 
 export const POSITIONS = {
   CREATE: 35878528,
@@ -215,12 +216,30 @@ export const MESSAGE_DATA = {
 export const buildNatsMessage = (
   { subject, data, streamSequence }:
   { subject: string, data: any, streamSequence: number }
-): NatsMessage => ({
+): JsMsg => ({
+  redelivered: false,
+  headers: undefined,
+  seq: 0,
+  sid: 0,
   subject,
-  info: {
+  info:  {
     streamSequence,
     pending: 0,
+    domain: "",
+    stream: "",
+    consumer: "",
+    redeliveryCount: 0,
+    deliverySequence: 0,
+    timestampNanos: 0,
+    redelivered: false
   },
   data: encodeData(data),
   ack: () => {},
+  nak: () => {},
+  working: () => {},
+  next: () => {},
+  term: () => {},
+  ackAck: async () => false,
+  json: <T>() => null as T,
+  string: () => "",
 })

--- a/core/src/specs/fixtures/nats-messages.ts
+++ b/core/src/specs/fixtures/nats-messages.ts
@@ -1,4 +1,5 @@
 import { JsMsg } from 'nats'
+
 import { encodeData } from '../../nats'
 
 export const POSITIONS = {


### PR DESCRIPTION
This replaces the customized `NatsMessage` by the supported type, `JsMsg`, by the library.