### PR TITLE
enh: enable skipLibCheck in tsconfig

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       working-directory: ./core
 
     - name: Run typescript
-      run: pnpm tsc --noEmit --skipLibCheck
+      run: pnpm tsc --noEmit
       working-directory: ./core
 
     - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 core-install:
 	@devbox run "cd core && pnpm install"
 core-test:
-	@devbox run "cd core && pnpm tsc --noEmit --skipLibCheck && pnpm test"
+	@devbox run "cd core && pnpm tsc --noEmit && pnpm test"
 
 worker-setup:
 	@cd worker && \

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "dist",
     // MikroORM
     "experimentalDecorators": true,
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "src/specs"]


### PR DESCRIPTION
This enables skipLibCheck in `tsconfig`.

- This resolves errors generated when running `tsc`.
