### PR TITLE
fix: set ignorePatterns in eslintrc

### DIFF
--- a/core/.eslintrc.js
+++ b/core/.eslintrc.js
@@ -2,9 +2,10 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'],
   parserOptions: {
-    sourceType: 'module'
+    sourceType: 'module',
   },
   env: {
-    node: true
-  }
+    node: true,
+  },
+  ignorePatterns: ['dist/**', 'node_modules/**'],
 }


### PR DESCRIPTION
This makes eslint ignore `dist` and `node_modules` 