### PR TITLE
Remove Neon beta notice

### DIFF
--- a/docs/docs/postgresql/source-database.md
+++ b/docs/docs/postgresql/source-database.md
@@ -93,16 +93,26 @@ Configure database for Bemi
 
 ### Neon
 
+#### WAL level {#neon-wal-level}
+
+To enable logical replication in [Neon](https://neon.tech/):
+
+1. Select your project in the Neon Console.
+2. On the Neon **Dashboard**, select **Settings**.
+3. Select **Beta**.
+4. Click **Enable** to enable logical replication. This will set the Postgres `wal_level` setting to `logical`.
+
 #### Connection {#neon-connection}
 
-To connect a [Neon](https://neon.tech/) database, specify your database credentials that can be found on the project's dashboard:
+To connect a [Neon](https://neon.tech/) Postgres database, specify your database credentials, which can be found on your Neon project's dashboard:
 
-* Please use the `Host` name without enabled "Pooled connection"
+**Note:** Please use the `Host` name without enabling the "Pooled connection" option.
 
 ![](/img/perm-neon.png)
 
 And that's it, everything should just work!
 
+For a detailed setup guide, see [Create an automatic audit trail with Bemi and Neon](https://neon.tech/docs/guides/bemi), in the _Neon documentation_.
 
 #### Read-only credentials {#neon-read-only}
 
@@ -134,11 +144,6 @@ END $$ LANGUAGE plpgsql;
 -- Call the created procedure
 CALL _bemi_set_replica_identity();
 ```
-
-#### WAL level {#neon-wal-level}
-
-If you have access to [Neon](https://neon.tech/)'s [Logical Replication Beta program](https://neon.tech/docs/guides/logical-replication-postgres),
-you can set WAL level to `logical` by enabling the feature in your Project settings.
 
 ### AWS RDS
 

--- a/docs/docs/postgresql/source-database.md
+++ b/docs/docs/postgresql/source-database.md
@@ -140,16 +140,6 @@ CALL _bemi_set_replica_identity();
 If you have access to [Neon](https://neon.tech/)'s [Logical Replication Beta program](https://neon.tech/docs/guides/logical-replication-postgres),
 you can set WAL level to `logical` by enabling the feature in your Project settings.
 
-If the Enrollment is paused for you, just send a support request email:
-
-```
-To: support@neon.tech
-Subject: Enable logical replication
-
-I need to integrate with Bemi.io, which requires logical replication.
-Can you please enable it for my [YOUR-DATABASE-HOST.neon.tech] database?
-```
-
 ### AWS RDS
 
 #### Connection {#aws-connection}


### PR DESCRIPTION
Neon's logical replication feature can now be enabled without requesting access. This PR removes the access request notice and makes a few additional revisions.

Thanks for considering!