### PR TITLE
refactor Change entity: Add hash property

### DIFF
--- a/core/src/entities/Change.ts
+++ b/core/src/entities/Change.ts
@@ -57,6 +57,9 @@ export class Change extends BaseEntity {
   @Property({ type: 'bigint' })
   position: number
 
+  @Property({ type: 'string', nullable: true })
+  hash: string | null
+
   constructor({
     primaryKey,
     before,
@@ -70,6 +73,7 @@ export class Change extends BaseEntity {
     queuedAt,
     transactionId,
     position,
+    hash = null,
   }: {
     primaryKey?: string
     before: object
@@ -83,6 +87,7 @@ export class Change extends BaseEntity {
     queuedAt: Date
     transactionId: number
     position: number
+    hash?: string | null
   }) {
     super()
     this.primaryKey = primaryKey
@@ -97,5 +102,6 @@ export class Change extends BaseEntity {
     this.queuedAt = queuedAt
     this.transactionId = transactionId
     this.position = position
+    this.hash = hash
   }
 }

--- a/core/src/ingestion.ts
+++ b/core/src/ingestion.ts
@@ -6,6 +6,7 @@ import { Change } from './entities/Change'
 import { FetchedRecord } from './fetched-record'
 import { FetchedRecordBuffer } from './fetched-record-buffer'
 import { stitchFetchedRecords } from './stitching'
+import { createHash } from 'crypto'
 
 const INSERT_INTERVAL_MS = 1000 // 1 second to avoid overwhelming the database
 const FETCH_EXPIRES_MS = 30_000 // 30 seconds, default
@@ -28,7 +29,10 @@ const persistFetchedRecords = async ({
   const batches = chunk(fetchedRecords, insertBatchSize)
 
   for (const fetchedRecs of batches) {
-    const changesAttributes = fetchedRecs.map(({ changeAttributes }) => changeAttributes)
+    const changesAttributes = fetchedRecs.map(({ changeAttributes }) => ({
+      ...changeAttributes,
+      hash: createHash('sha256').update(JSON.stringify(changeAttributes)).digest('hex'),
+    }))
     const queryBuilder = orm.em.createQueryBuilder(Change).insert(changesAttributes).onConflict().ignore()
     await queryBuilder.execute()
   }

--- a/core/src/migrations/.snapshot-db_799e557d9277.json
+++ b/core/src/migrations/.snapshot-db_799e557d9277.json
@@ -145,6 +145,15 @@
           "primary": false,
           "nullable": false,
           "mappedType": "bigint"
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "string"
         }
       },
       "name": "changes",

--- a/core/src/migrations/Migration20241205185755.ts
+++ b/core/src/migrations/Migration20241205185755.ts
@@ -1,0 +1,12 @@
+import { Migration } from '@mikro-orm/migrations'
+
+export class Migration20241205185755 extends Migration {
+  async up(): Promise<void> {
+    // add a column of hash which is nullable
+    this.addSql('alter table "changes" add column "hash" varchar(255) null;')
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "changes" drop column "hash";')
+  }
+}


### PR DESCRIPTION
## Summary

Adds a nullable `hash` column to the `changes` table and populates it at ingestion time with a SHA-256 of `JSON.stringify(changeAttributes)`.

## Why

To support deduplication / idempotency of ingested changes. The ingestion path already uses `onConflict().ignore()` on insert, but conflicts are only caught on the existing unique keys — identical change payloads that don't collide on those keys can still be persisted twice (e.g. when a fetch is retried or replayed). Storing a stable fingerprint of `changeAttributes` lets us detect and skip duplicates downstream, and leaves the door open to a unique index on `hash` once existing rows are backfilled.

The column is nullable so existing rows are unaffected; no backfill is performed in this PR.

## Changes

- `core/src/entities/Change.ts` — add `hash: string | null` property.
- `core/src/migrations/Migration20241205185755.ts` — add nullable `hash varchar(255)` column to `changes`.
- `core/src/ingestion.ts` — compute `sha256(JSON.stringify(changeAttributes))` per record before insert.

## Test plan

- [ ] `core` builds
- [ ] Run migration `Migration20241205185755` up/down
- [ ] Verify ingestion writes a non-null `hash` for new rows and existing rows remain NULL